### PR TITLE
fix: use custom Future to wait decoder and processor simultaneously

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -838,6 +838,7 @@ dependencies = [
  "monolake-core",
  "native-tls",
  "openssl-sys",
+ "pin-project-lite",
  "ppp",
  "rand",
  "rustls",

--- a/monolake-services/Cargo.toml
+++ b/monolake-services/Cargo.toml
@@ -28,9 +28,9 @@ monoio-native-tls = { version = "0.1.0" }
 native-tls = "0.2"
 openssl-sys = "0.9"
 
-
 async-channel = "1"
 tower-layer = "0"
 rand = "0"
 matchit = "0"
 ppp = "2"
+pin-project-lite = "0.2"

--- a/monolake-services/src/http/mod.rs
+++ b/monolake-services/src/http/mod.rs
@@ -1,8 +1,11 @@
-mod core;
-pub use self::core::HttpCoreService;
 use http::{HeaderMap, HeaderValue, Response, StatusCode};
 use monoio_http::h1::payload::Payload;
+
+pub use self::core::HttpCoreService;
+
+mod core;
 pub mod handlers;
+mod util;
 
 const CONNECTION: &str = "Connection";
 const CONN_CLOSE: &[u8] = b"close";

--- a/monolake-services/src/http/util.rs
+++ b/monolake-services/src/http/util.rs
@@ -1,0 +1,73 @@
+use std::{future::Future, task::Poll};
+
+pin_project_lite::pin_project! {
+    /// MaybeDoubleFuture for http decoder and processor.
+    #[project = EnumProj]
+    pub(crate) enum MaybeDoubleFuture<FA, FB, T> {
+        Single{#[pin] fut: FA},
+        Double{
+            #[pin] future_a: FA,
+            #[pin] future_b: FB,
+            slot_a: Option<T>,
+            ready_b: bool
+        },
+    }
+}
+
+impl<FA, FB, T> Future for MaybeDoubleFuture<FA, FB, T>
+where
+    FA: Future<Output = T>,
+    FB: Future,
+{
+    type Output = T;
+
+    fn poll(self: std::pin::Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
+        match self.project() {
+            EnumProj::Single { fut } => fut.poll(cx),
+            EnumProj::Double {
+                future_a,
+                future_b,
+                slot_a,
+                ready_b,
+            } => {
+                // try poll future_b if not ready
+                if !*ready_b && matches!(future_b.poll(cx), Poll::Ready(_)) {
+                    *ready_b = true;
+                }
+                // poll future_a if not ready
+                if slot_a.is_none() {
+                    if let Poll::Ready(t) = future_a.poll(cx) {
+                        *slot_a = Some(t);
+                    }
+                }
+                // if future_b is not ready, return pending
+                if !*ready_b {
+                    return Poll::Pending;
+                }
+                // now future_b is ready, check a
+                match slot_a.take() {
+                    Some(t) => Poll::Ready(t),
+                    None => Poll::Pending,
+                }
+            }
+        }
+    }
+}
+
+impl<FA, FB, T> MaybeDoubleFuture<FA, FB, T>
+where
+    FA: Future<Output = T>,
+{
+    pub(crate) fn new(future_a: FA, future_b: Option<FB>) -> MaybeDoubleFuture<FA, FB, T> {
+        if let Some(future_b) = future_b {
+            MaybeDoubleFuture::Double {
+                future_a,
+                future_b,
+                slot_a: None,
+                ready_b: false,
+            }
+        } else {
+            MaybeDoubleFuture::Single { fut: future_a }
+        }
+    }
+}


### PR DESCRIPTION
Previous open-sourced version spawns the `process_request` task, which may cause responses to be out of order and encoder borrowed multiple times at the same time.
In former PR I removed the spawn, but this may cause no task feeding the chunked stream and block.
Here we must wait the decoder and `process_request` at the same time. Except `spawn`, we can also use custom Future and writing poll manually.

In this PR:
1. I added a custom Future to wait 2 tasks simultaneously.
2. Remove useless and dangerous `Rc<UnsafeCell<...>>`.