### PR TITLE
refactor: make tls an optional feature

### DIFF
--- a/monolake-services/Cargo.toml
+++ b/monolake-services/Cargo.toml
@@ -12,22 +12,30 @@ openid = [
     "dep:lazy_static",
 ]
 proxy-protocol = ["dep:proxy-protocol"]
+tls = [
+    "dep:monoio-rustls",
+    "dep:rustls",
+    "dep:rustls-pemfile",
+    "dep:webpki-roots",
+    "dep:monoio-native-tls",
+    "dep:native-tls",
+]
 
 [dependencies]
 monoio = { workspace = true, features = ['splice'] }
 monolake-core = { path = "../monolake-core" }
 monoio-http = { workspace = true }
 monoio-http-client = { workspace = true, features = ["logging", "rustls"] }
-local-sync = {workspace = true}
-service-async = {workspace = true}
+local-sync = { workspace = true }
+service-async = { workspace = true }
 
 # tls
-monoio-rustls = {workspace = true}
-rustls = { version = "0.21" }
-rustls-pemfile = "1"
-webpki-roots = "0.23"
-monoio-native-tls = {workspace = true}
-native-tls = "0.2"
+monoio-rustls = { workspace = true, optional = true }
+rustls = { version = "0.21", optional = true }
+rustls-pemfile = { version = "1", optional = true }
+webpki-roots = { version = "0.23", optional = true }
+monoio-native-tls = { workspace = true, optional = true }
+native-tls = { version = "0.2", optional = true }
 
 # common
 anyhow = "1"

--- a/monolake-services/src/lib.rs
+++ b/monolake-services/src/lib.rs
@@ -4,7 +4,9 @@
 pub mod common;
 pub mod http;
 pub mod tcp;
-pub mod tls;
 
 #[cfg(feature = "proxy-protocol")]
 pub mod proxy_protocol;
+
+#[cfg(feature = "tls")]
+pub mod tls;

--- a/monolake/Cargo.toml
+++ b/monolake/Cargo.toml
@@ -6,12 +6,13 @@ keywords = ["monoio", "http", "async"]
 description = "High Performance Proxy base on Monoio"
 
 [features]
-default = []
+default = ["tls"]
 openid = ["monolake-core/openid", "monolake-services/openid"]
 proxy-protocol = [
     "monolake-core/proxy-protocol",
     "monolake-services/proxy-protocol",
 ]
+tls = ["dep:monoio-native-tls", "monolake-services/tls"]
 
 [dependencies]
 monoio = { workspace = true, features = ["sync", "async-cancel"] }
@@ -22,7 +23,7 @@ monolake-core = { path = "../monolake-core" }
 monolake-services = { path = "../monolake-services" }
 
 # tls: needed for native-tls init
-monoio-native-tls = { workspace = true }
+monoio-native-tls = { workspace = true, optional = true }
 
 # error
 anyhow = "1"

--- a/monolake/src/config/extractor.rs
+++ b/monolake/src/config/extractor.rs
@@ -1,7 +1,7 @@
 use certain_map::Param;
 #[cfg(feature = "openid")]
 use monolake_services::http::handlers::openid::OpenIdConfig;
-use monolake_services::{http::Keepalive, tls::TlsConfig};
+use monolake_services::http::Keepalive;
 
 use super::{RouteConfig, ServerConfig};
 
@@ -26,8 +26,9 @@ impl Param<Vec<RouteConfig>> for ServerConfig {
     }
 }
 
-impl Param<TlsConfig> for ServerConfig {
-    fn param(&self) -> TlsConfig {
+#[cfg(feature = "tls")]
+impl Param<monolake_services::tls::TlsConfig> for ServerConfig {
+    fn param(&self) -> monolake_services::tls::TlsConfig {
         self.tls.clone()
     }
 }

--- a/monolake/src/main.rs
+++ b/monolake/src/main.rs
@@ -37,6 +37,7 @@ async fn main() -> Result<()> {
                 .from_env_lossy(),
         )
         .init();
+    #[cfg(feature = "tls")]
     monoio_native_tls::init();
     print_logo();
 


### PR DESCRIPTION
Not everyone needs tls. For some scenarios, tls also makes static compilation difficult.

Here I make tls an optional feature and enable it by default.
Under my test, both of these builds are success:
```bash
cargo build --target=x86_64-unknown-linux-musl --no-default-features
RUSTFLAGS="-C target-feature=+crt-static" cargo build --target x86_64-unknown-linux-gnu --no-default-features
```