### PR TITLE
fix: start main thread with driver type in config

### DIFF
--- a/monolake-core/src/config/mod.rs
+++ b/monolake-core/src/config/mod.rs
@@ -41,7 +41,7 @@ impl Default for RuntimeConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum RuntimeType {
     #[cfg(target_os = "linux")]

--- a/monolake-core/src/util/mod.rs
+++ b/monolake-core/src/util/mod.rs
@@ -18,3 +18,7 @@ pub async fn file_read(path: impl AsRef<Path>) -> std::io::Result<Vec<u8>> {
     res?;
     Ok(buf.into_inner())
 }
+
+pub fn file_read_sync(path: impl AsRef<Path>) -> std::io::Result<Vec<u8>> {
+    std::fs::read(path)
+}

--- a/monolake/src/config/mod.rs
+++ b/monolake/src/config/mod.rs
@@ -112,7 +112,7 @@ impl TryFrom<ListenerConfig> for ListenerBuilder {
 }
 
 impl Config {
-    pub async fn load(path: impl AsRef<Path>) -> anyhow::Result<Self> {
+    pub fn load(path: impl AsRef<Path>) -> anyhow::Result<Self> {
         #[derive(Debug, Clone, Serialize, Deserialize)]
         pub struct UserConfig {
             #[serde(default)]
@@ -120,7 +120,7 @@ impl Config {
             pub servers: HashMap<String, ServiceConfig<ListenerConfig, ServerUserConfig>>,
         }
         // 1. load from file -> UserConfig
-        let file_context = monolake_core::util::file_read(path).await?;
+        let file_context = monolake_core::util::file_read_sync(path)?;
         let user_config = Self::from_slice::<UserConfig>(&file_context)?;
 
         // 2. UserConfig -> Config
@@ -131,8 +131,8 @@ impl Config {
             #[cfg(feature = "tls")]
             let tls = match server.tls {
                 Some(inner) => {
-                    let chain = monolake_core::util::file_read(&inner.chain).await?;
-                    let key = monolake_core::util::file_read(&inner.key).await?;
+                    let chain = monolake_core::util::file_read_sync(&inner.chain)?;
+                    let key = monolake_core::util::file_read_sync(&inner.key)?;
                     match inner.stack {
                         TlsStack::Rustls => {
                             monolake_services::tls::TlsConfig::Rustls((chain, key)).try_into()?


### PR DESCRIPTION
Current main thread booted with macro, which causes driver type uncertain. However, UDS listener requires sensing driver type to set `non_blocking`.

Here I changed the main thread to use the configured driver type, which is the same as the workers.