### PR TITLE
fix: set cpu affinity correctly and not bind by default

### DIFF
--- a/monolake-core/src/config/mod.rs
+++ b/monolake-core/src/config/mod.rs
@@ -115,7 +115,7 @@ fn default_workers() -> usize {
 }
 
 define_const!(default_entries, DEFAULT_ENTRIES, u32);
-define_const!(default_cpu_affinity, true, bool);
+define_const!(default_cpu_affinity, false, bool);
 
 // #[cfg(test)]
 // mod tests {


### PR DESCRIPTION
1. **Set cpu affinity correctly.** Current impl is not correct, it bind the main thread to different cores multiple times. It may brought by some previous refactor.
2. **Change default cpu affinity config to false.** Bind thread to cores can make the performance better some time, but for container environment, bind to core may cause different process compete for one core, which can do harm to performance. So in this PR, by default it is disabled.