### PR TITLE
Feat: Make ContentHandler a runtime optional handler

### DIFF
--- a/examples/config.toml
+++ b/examples/config.toml
@@ -7,6 +7,7 @@ entries = 1024
 name = "gateway.monolake.rs"
 listener = { type = "socket", value = "0.0.0.0:8080" }
 upstream_http_version = "http2"
+http_opt_handlers = { content_handler = true }
 
 [[servers.demo_basic.routes]]
 path = '/'

--- a/monolake-services/src/http/handlers/content_handler.rs
+++ b/monolake-services/src/http/handlers/content_handler.rs
@@ -204,4 +204,16 @@ impl<F> ContentHandler<F> {
     pub fn layer<C>() -> impl FactoryLayer<C, F, Factory = Self> {
         layer_fn(|_: &C, inner| Self { inner })
     }
+
+    /// Returns a factory layer for the `ContentHandler`.
+    ///
+    /// This allows the 'ContentHandler to be selectively enabled or
+    /// disabled based on a configuration at runtime.
+    pub fn opt_layer<C>(enabled: bool) -> Option<impl FactoryLayer<C, F, Factory = Self>> {
+        if enabled {
+            Some(layer_fn(|_: &C, inner| Self { inner }))
+        } else {
+            None
+        }
+    }
 }

--- a/monolake/src/config/mod.rs
+++ b/monolake/src/config/mod.rs
@@ -40,6 +40,7 @@ pub struct ServerConfig {
     pub http_server_timeout: HttpServerTimeout,
     pub http_upstream_timeout: HttpUpstreamTimeout,
     pub upstream_http_version: HttpVersion,
+    pub http_opt_handlers: HttpOptHandlers,
     pub thrift_server_timeout: ThriftServerTimeout,
     #[cfg(feature = "openid")]
     pub auth_config: Option<AuthConfig>,
@@ -55,6 +56,8 @@ pub struct ServerUserConfig {
     pub http_timeout: Option<HttpTimeout>,
     #[serde(default = "HttpVersion::default")]
     pub upstream_http_version: HttpVersion,
+    #[serde(default)]
+    pub http_opt_handlers: HttpOptHandlers,
     pub thrift_timeout: Option<ThriftTimeout>,
 }
 
@@ -99,6 +102,12 @@ pub enum TlsStack {
     #[default]
     Rustls,
     NativeTls,
+}
+
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct HttpOptHandlers {
+    // Enable content handler in the handler chain
+    pub content_handler: bool,
 }
 
 #[cfg(feature = "openid")]
@@ -197,6 +206,7 @@ impl Config {
                         upstream_http_version: server.upstream_http_version,
                         #[cfg(feature = "openid")]
                         auth_config: None,
+                        http_opt_handlers: server.http_opt_handlers,
                     },
                     listener,
                 },

--- a/monolake/src/factory.rs
+++ b/monolake/src/factory.rs
@@ -41,11 +41,12 @@ pub fn l7_factory(
 > {
     match config.proxy_type {
         crate::config::ProxyType::Http => {
-            let protocol: HttpVersion = config.param();
+            let version: HttpVersion = config.param();
             let http_upstream_timeout: HttpUpstreamTimeout = config.param();
+            let enable_content_handler = config.http_opt_handlers.content_handler;
             let stacks = FactoryStack::new(config.clone())
-                .replace(UpstreamHandler::factory(http_upstream_timeout, protocol))
-                .push(ContentHandler::layer())
+                .replace(UpstreamHandler::factory(http_upstream_timeout, version))
+                .push(ContentHandler::opt_layer(enable_content_handler))
                 .push(RewriteAndRouteHandler::layer());
 
             #[cfg(feature = "openid")]


### PR DESCRIPTION
- Make `ContentHandler` an optional handler
- Introduced `opt_layer` for `ContentHandler` to illustrate how to dynamically include or exclude a handler from a chain based on runtime configuration