### PR TITLE
fix: fix potential UB caused by unsafe and future movement

### DIFF
--- a/monolake-services/src/common/cancel/mod.rs
+++ b/monolake-services/src/common/cancel/mod.rs
@@ -86,7 +86,7 @@ impl Waiter {
     pub fn cancelled(&self) -> bool {
         self.handler
             .upgrade()
-            .map_or(true, |handler| unsafe { &*handler.get() }.cancelled)
+            .is_none_or(|handler| unsafe { &*handler.get() }.cancelled)
     }
 }
 

--- a/monolake-services/src/http/util.rs
+++ b/monolake-services/src/http/util.rs
@@ -1,90 +1,152 @@
-use std::{future::Future, task::Poll};
+use std::{
+    future::Future,
+    mem::{ManuallyDrop, MaybeUninit},
+    ops::DerefMut,
+    pin::Pin,
+    task::Poll,
+};
 
 use http::{HeaderValue, Request, Response, StatusCode};
 use monoio_http::common::body::FixedBody;
 use monolake_core::http::{HttpError, HttpHandler, ResponseWithContinue};
 use service_async::Service;
 
-pin_project_lite::pin_project! {
-    /// AccompanyPair for http decoder and processor.
-    /// We have to fill payload when process request
-    /// since inner logic may read chunked body; also
-    /// fill payload when process response since we
-    /// may use the request body stream in response
-    /// body stream.
-    pub(crate) struct AccompanyPair<FMAIN, FACC, T> {
-        #[pin]
-        main: FMAIN,
-        #[pin]
-        accompany: FACC,
-        accompany_slot: Option<T>
-    }
+union Union<A, B> {
+    a: ManuallyDrop<A>,
+    b: ManuallyDrop<B>,
 }
 
-pin_project_lite::pin_project! {
-    /// Accompany for http decoder and processor.
-    pub(crate) struct Accompany<FACC, T> {
-        #[pin]
-        accompany: FACC,
-        accompany_slot: Option<T>
-    }
+/// AccompanyPair for http decoder and processor.
+/// We have to fill payload when process request
+/// since inner logic may read chunked body; also
+/// fill payload when process response since we
+/// may use the request body stream in response
+/// body stream.
+pub(crate) struct AccompanyPairBase<F1, F2, FACC, T> {
+    main: MaybeUninit<Union<F1, F2>>,
+    accompany: FACC,
+    accompany_slot: Option<T>,
 }
 
-impl<FMAIN, FACC, T> Future for AccompanyPair<FMAIN, FACC, T>
-where
-    FMAIN: Future,
-    FACC: Future<Output = T>,
-{
-    type Output = FMAIN::Output;
-
-    fn poll(self: std::pin::Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
-        let this = self.project();
-        if this.accompany_slot.is_none()
-            && let Poll::Ready(t) = this.accompany.poll(cx)
-        {
-            *this.accompany_slot = Some(t);
-        }
-        this.main.poll(cx)
-    }
-}
-
-impl<FACC, T> Future for Accompany<FACC, T>
-where
-    FACC: Future<Output = T>,
-{
-    type Output = T;
-
-    fn poll(self: std::pin::Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
-        let this = self.project();
-        if let Some(t) = this.accompany_slot.take() {
-            return Poll::Ready(t);
-        }
-        this.accompany.poll(cx)
-    }
-}
-
-impl<FMAIN, FACC, T> AccompanyPair<FMAIN, FACC, T> {
-    pub(crate) fn new(main: FMAIN, accompany: FACC) -> Self {
+impl<F1, F2, FACC, T> AccompanyPairBase<F1, F2, FACC, T> {
+    pub(crate) const fn new(accompany: FACC) -> Self {
         Self {
-            main,
+            main: MaybeUninit::uninit(),
             accompany,
             accompany_slot: None,
         }
     }
 
-    pub(crate) fn replace<FMAIN2>(self, main: FMAIN2) -> AccompanyPair<FMAIN2, FACC, T> {
-        AccompanyPair {
-            main,
-            accompany: self.accompany,
-            accompany_slot: self.accompany_slot,
+    pub(crate) fn stage1(
+        mut self: Pin<&mut Self>,
+        future1: F1,
+    ) -> AccompanyPairS1<F1, F2, FACC, T> {
+        unsafe {
+            self.as_mut().get_unchecked_mut().main.assume_init_mut().a = ManuallyDrop::new(future1);
         }
+        AccompanyPairS1(self)
     }
 
-    pub(crate) fn into_accompany(self) -> Accompany<FACC, T> {
-        Accompany {
-            accompany: self.accompany,
-            accompany_slot: self.accompany_slot,
+    pub(crate) fn stage2(
+        mut self: Pin<&mut Self>,
+        future2: F2,
+    ) -> AccompanyPairS2<F1, F2, FACC, T> {
+        unsafe {
+            self.as_mut().get_unchecked_mut().main.assume_init_mut().b = ManuallyDrop::new(future2);
         }
+        AccompanyPairS2(self)
+    }
+
+    pub(crate) const fn stage3(self: Pin<&mut Self>) -> AccompanyPairS3<F1, F2, FACC, T> {
+        AccompanyPairS3(self)
+    }
+}
+
+#[repr(transparent)]
+pub(crate) struct AccompanyPairS1<'a, F1, F2, FACC, T>(
+    Pin<&'a mut AccompanyPairBase<F1, F2, FACC, T>>,
+);
+
+impl<F1, F2, FACC, T> Drop for AccompanyPairS1<'_, F1, F2, FACC, T> {
+    fn drop(&mut self) {
+        unsafe {
+            ManuallyDrop::drop(&mut self.0.as_mut().get_unchecked_mut().main.assume_init_mut().a);
+        }
+    }
+}
+
+impl<F1, F2, FACC, T> Future for AccompanyPairS1<'_, F1, F2, FACC, T>
+where
+    F1: Future,
+    FACC: Future<Output = T>,
+{
+    type Output = F1::Output;
+
+    fn poll(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Self::Output> {
+        let this = unsafe { self.0.as_mut().get_unchecked_mut() };
+        if this.accompany_slot.is_none()
+            && let Poll::Ready(t) = unsafe { Pin::new_unchecked(&mut this.accompany) }.poll(cx)
+        {
+            this.accompany_slot = Some(t);
+        }
+        unsafe { Pin::new_unchecked(this.main.assume_init_mut().a.deref_mut()).poll(cx) }
+    }
+}
+
+#[repr(transparent)]
+pub(crate) struct AccompanyPairS2<'a, F1, F2, FACC, T>(
+    Pin<&'a mut AccompanyPairBase<F1, F2, FACC, T>>,
+);
+
+impl<F1, F2, FACC, T> Drop for AccompanyPairS2<'_, F1, F2, FACC, T> {
+    fn drop(&mut self) {
+        unsafe {
+            ManuallyDrop::drop(&mut self.0.as_mut().get_unchecked_mut().main.assume_init_mut().b);
+        }
+    }
+}
+
+impl<F1, F2, FACC, T> Future for AccompanyPairS2<'_, F1, F2, FACC, T>
+where
+    F2: Future,
+    FACC: Future<Output = T>,
+{
+    type Output = F2::Output;
+
+    fn poll(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Self::Output> {
+        let this = unsafe { self.0.as_mut().get_unchecked_mut() };
+        if this.accompany_slot.is_none()
+            && let Poll::Ready(t) = unsafe { Pin::new_unchecked(&mut this.accompany) }.poll(cx)
+        {
+            this.accompany_slot = Some(t);
+        }
+        unsafe { Pin::new_unchecked(this.main.assume_init_mut().b.deref_mut()).poll(cx) }
+    }
+}
+
+#[repr(transparent)]
+pub(crate) struct AccompanyPairS3<'a, F1, F2, FACC, T>(
+    Pin<&'a mut AccompanyPairBase<F1, F2, FACC, T>>,
+);
+
+impl<F1, F2, FACC: Future<Output = T>, T> Future for AccompanyPairS3<'_, F1, F2, FACC, T> {
+    type Output = FACC::Output;
+
+    fn poll(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Self::Output> {
+        let this = unsafe { self.0.as_mut().get_unchecked_mut() };
+        if let Some(t) = this.accompany_slot.take() {
+            return Poll::Ready(t);
+        }
+        unsafe { Pin::new_unchecked(&mut this.accompany) }.poll(cx)
     }
 }
 


### PR DESCRIPTION
Fix potential UB issues caused by misusing unsafe and moving futures (this issue has not yet caused adverse consequences).

When we are handling http decoding and encoding, we want the `request decoding`(including body receiving) future handled together with `processing`/`response encoding` future.

In old solutions I created multiple custom `Future`s to do it. But it involved future movement, so in fact it violated the safety constraint. Though this does not actually caused problem, but it depends on compiler implemenation details and may cause hard-find bugs.

In the new implementation, I created a unified state and multiple wrappers representing different stages and use safe interface as much as possible. Thus we can make sure the future itself is pinned on stack.